### PR TITLE
v1.1.1

### DIFF
--- a/src/components/common/BasePanel.vue
+++ b/src/components/common/BasePanel.vue
@@ -6,16 +6,19 @@
       </template>
     </PanelHeader>
 
-    <div class="base-panel__content" :class="contentClass">
+    <div class="base-panel__content" :class="contentClass" ref="contentEl">
       <slot />
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue'
 import PanelHeader from './PanelHeader.vue'
 import colors from '@/assets/theme/colors'
 
+const contentEl = ref<HTMLElement | null>(null)
+defineExpose({ contentEl })
 interface Props {
   title: string
   panelClass?: string

--- a/src/components/common/BasePanel.vue
+++ b/src/components/common/BasePanel.vue
@@ -47,5 +47,6 @@ withDefaults(defineProps<Props>(), {
 .base-panel__content {
   flex: 1;
   min-height: 0;
+  position: relative;
 }
 </style>

--- a/src/components/common/BasePanel.vue
+++ b/src/components/common/BasePanel.vue
@@ -1,0 +1,51 @@
+<template>
+  <section class="base-panel" :class="panelClass">
+    <PanelHeader :title="title">
+      <template v-if="$slots.actions" #actions>
+        <slot name="actions" />
+      </template>
+    </PanelHeader>
+
+    <div class="base-panel__content" :class="contentClass">
+      <slot />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import PanelHeader from './PanelHeader.vue'
+import colors from '@/assets/theme/colors'
+
+interface Props {
+  title: string
+  panelClass?: string
+  contentClass?: string
+}
+
+withDefaults(defineProps<Props>(), {
+  panelClass: '',
+  contentClass: '',
+})
+</script>
+
+<style scoped>
+.base-panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  background-color: v-bind('colors["background-light"]');
+  border: 2px solid v-bind('colors["border-light"]');
+  border-radius: 0.75rem;
+}
+.dark .base-panel {
+  background-color: v-bind('colors["background-dark"]');
+  border-color: v-bind('colors["border-dark"]');
+}
+
+.base-panel__content {
+  flex: 1;
+  min-height: 0;
+}
+</style>

--- a/src/components/prompt-text/PromptTextPanel.vue
+++ b/src/components/prompt-text/PromptTextPanel.vue
@@ -1,36 +1,34 @@
 <template>
-  <section class="prompt-panel">
-    <PanelHeader title="Tagged Prompt">
-      <template #actions>
-        <button type="button" class="prompt-panel__copy" @click="handleCopy">
-          {{ copyLabel }}
-        </button>
-      </template>
-    </PanelHeader>
+  <BasePanel title="Tagged Prompt" content-class="prompt-panel__editor">
+    <template #actions>
+      <button type="button" class="prompt-panel__copy" @click="handleCopy">
+        {{ copyLabel }}
+      </button>
+    </template>
 
-    <div ref="editorRef" class="prompt-panel__editor">
-      <PromptTextDisplay
-        :text="rawText"
-        :scroll-top="scrollState.scrollTop"
-        :scroll-left="scrollState.scrollLeft"
-      />
-      <PromptTextArea
-        ref="areaRef"
-        :model-value="rawText"
-        :placeholder="placeholder"
-        @input="handleInput"
-        @keydown="handleKeydown"
-        @scroll="handleScroll"
-      />
-      <PromptTextAutoComplete
-        :anchor="suggestionAnchor"
-        :suggestions="suggestions"
-        :visible="isSuggestionVisible"
-        :active-index="activeSuggestionIndex"
-        @select="handleSuggestionSelect"
-      />
-    </div>
-  </section>
+    <!-- div 제거하고 직접 내용 배치 -->
+    <PromptTextDisplay
+      ref="editorRef"
+      :text="rawText"
+      :scroll-top="scrollState.scrollTop"
+      :scroll-left="scrollState.scrollLeft"
+    />
+    <PromptTextArea
+      ref="areaRef"
+      :model-value="rawText"
+      :placeholder="placeholder"
+      @input="handleInput"
+      @keydown="handleKeydown"
+      @scroll="handleScroll"
+    />
+    <PromptTextAutoComplete
+      :anchor="suggestionAnchor"
+      :suggestions="suggestions"
+      :visible="isSuggestionVisible"
+      :active-index="activeSuggestionIndex"
+      @select="handleSuggestionSelect"
+    />
+  </BasePanel>
 </template>
 
 <script setup lang="ts">
@@ -41,8 +39,7 @@ import PromptTextAutoComplete from './PromptTextAutoComplete.vue'
 import { usePromptEditorStore } from '@/stores/promptEditorStore'
 import { getCaretMetrics } from '@/composables/useCaretPosition'
 import { storeToRefs } from 'pinia'
-import PanelHeader from '../common/PanelHeader.vue'
-import colors from '@/assets/theme/colors'
+import BasePanel from '../common/BasePanel.vue'
 
 const placeholder = '여기에 태그 기반 프롬프트를 입력해주세요.'
 
@@ -888,21 +885,6 @@ function handleRedo() {
 </script>
 
 <style scoped>
-.prompt-panel {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-height: 0;
-  background-color: v-bind('colors["background-light"]');
-  border: 2px solid v-bind('colors["border-light"]');
-  border-radius: 0.75rem;
-}
-.dark .prompt-panel {
-  background-color: v-bind('colors["background-dark"]');
-  border-color: v-bind('colors["border-dark"]');
-}
-
 .prompt-panel__copy {
   padding: 0.3rem 0.9rem;
   border-radius: 0.5rem;

--- a/src/components/tag-block/TagBlockElement.vue
+++ b/src/components/tag-block/TagBlockElement.vue
@@ -84,9 +84,6 @@ function handleCreateChild() {
 
 <style scoped>
 .tag-element {
-  background: v-bind('colors["background-light"] + "10"');
-  border: 2px solid v-bind('colors["border-light"] + "aa"');
-  border-radius: 0.75rem;
   padding: 0.9rem;
   display: flex;
   flex-direction: column;
@@ -94,10 +91,6 @@ function handleCreateChild() {
   transition: border-color 0.2s ease;
   position: relative;
   z-index: 1;
-}
-.dark .tag-element {
-  background: v-bind('colors["background-dark"] + "10"');
-  border-color: v-bind('colors["border-dark"] + "aa"');
 }
 
 .tag-element:hover {

--- a/src/components/tag-block/TagBlockPanel.vue
+++ b/src/components/tag-block/TagBlockPanel.vue
@@ -1,23 +1,16 @@
 <template>
-  <section class="tag-panel">
-    <PanelHeader title="Visual Block Renderer" />
-    <div class="tag-panel__body">
-      <template v-if="nodes.length">
-        <template v-for="node in nodes" :key="node.id">
-          <TagBlockElement v-if="node.type === 'element'" :node="node" />
-          <TagBlockText
-            v-else
-            :node="node"
-            :disabled="node.enabled === false"
-          />
-        </template>
+  <BasePanel title="Visual Block Renderer" content-class="tag-panel__body">
+    <template v-if="nodes.length">
+      <template v-for="node in nodes" :key="node.id">
+        <TagBlockElement v-if="node.type === 'element'" :node="node" />
+        <TagBlockText v-else :node="node" :disabled="node.enabled === false" />
       </template>
-      <p v-else class="tag-panel__placeholder">
-        왼쪽 텍스트 영역에 유효한 태그를 입력해 주세요. (예:
-        &lt;tag&gt;내용&lt;/tag&gt;)
-      </p>
-    </div>
-  </section>
+    </template>
+    <p v-else class="tag-panel__placeholder">
+      왼쪽 텍스트 영역에 유효한 태그를 입력해 주세요. (예:
+      &lt;tag&gt;내용&lt;/tag&gt;)
+    </p>
+  </BasePanel>
 </template>
 
 <script setup lang="ts">
@@ -25,29 +18,14 @@ import { storeToRefs } from 'pinia'
 import { usePromptEditorStore } from '@/stores/promptEditorStore'
 import TagBlockElement from './TagBlockElement.vue'
 import TagBlockText from './TagBlockText.vue'
-import PanelHeader from '../common/PanelHeader.vue'
 import colors from '@/assets/theme/colors'
+import BasePanel from '../common/BasePanel.vue'
 
 const store = usePromptEditorStore()
 const { parsedNodes: nodes } = storeToRefs(store)
 </script>
 
 <style scoped>
-.tag-panel {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-height: 0;
-  background-color: v-bind('colors["background-light"]');
-  border: 2px solid v-bind('colors["border-light"]');
-  border-radius: 0.75rem;
-}
-
-.dark .tag-panel {
-  background-color: v-bind('colors["background-dark"]');
-  border-color: v-bind('colors["border-dark"]');
-}
-
 .tag-panel__body {
   flex: 1;
   overflow-y: auto;


### PR DESCRIPTION
This pull request refactors the panel components used in the prompt and tag block sections to improve code reuse and maintainability. It introduces a new reusable `BasePanel` component that replaces duplicated panel markup and styling in both the prompt and tag block panels. The changes also simplify layout and remove redundant styles.

**Component Refactoring and Reuse:**

* Introduced a new reusable `BasePanel` component in `src/components/common/BasePanel.vue` to standardize panel structure, header, and styling.
* Replaced direct usage of `PanelHeader` and custom panel markup with the new `BasePanel` in both `PromptTextPanel.vue` and `TagBlockPanel.vue`.

**Styling and Layout Simplification:**

* Removed duplicated panel CSS from `PromptTextPanel.vue` and `TagBlockPanel.vue`, consolidating styling into `BasePanel.vue`.